### PR TITLE
Start list of relevant conferences

### DIFF
--- a/resources/conferences.md
+++ b/resources/conferences.md
@@ -2,9 +2,18 @@
 
 ## Yearly Conferences
 
-| Conference name | Month | Topic |
-| [<abbr title="Investigative Reporters and Editors' Computer Assisted Reporting conference">NICAR</abbr>](https://www.ire.org/conferences) | March | Computer-assisted reporting |
-| [<abbr title="Society for News Design">SND</abbr>](https://www.snd.org/training/) | April | Design |
-| [SRCCON](https://srccon.org/) | June | Teamwork challenges in news |
-| [WordCamp for Publishers](https://twitter.com/wcpublishers/) | August | WordPress |
-| [<abbr title="Online News Association">ONA</abbr>](https://journalists.org/events/) | September | Online news |
+| Conference name | Month | Topic | Location |
+| [<abbr title="Investigative Reporters and Editors' Computer Assisted Reporting conference">NICAR</abbr>](https://www.ire.org/conferences) | March | Computer-assisted reporting | United States |
+| [<abbr title="Society for News Design">SND</abbr>](https://www.snd.org/training/) | April | Design | United States |
+| [SRCCON](https://srccon.org/) | June | Teamwork challenges in news | United States |
+| [Media Party](http://mediaparty.info/en/) | August | Buenos Aires |
+| [WordCamp for Publishers](https://twitter.com/wcpublishers/) | August | WordPress | United States |
+| [<abbr title="Online News Association">ONA</abbr>](https://journalists.org/events/) | September | Online news | United States |
+
+## Lists of lists of events
+
+- [OpenNews Source's list of event roundups](https://source.opennews.org/articles/tags/events/)
+- [Hacks/Hackers event list](https://hackshackers.com/)
+- [IRE events and training calendar](https://www.ire.org/events-and-training)
+- [ONA events calendar](https://journalists.org/events/)
+- [SND events calendar](https://www.snd.org/industry-events/)

--- a/resources/conferences.md
+++ b/resources/conferences.md
@@ -1,0 +1,10 @@
+# Journalism-Tech Conferences
+
+## Yearly Conferences
+
+| Conference name | Month | Topic |
+| [<abbr title="Investigative Reporters and Editors' Computer Assisted Reporting conference">NICAR</abbr>](https://www.ire.org/conferences) | March | Computer-assisted reporting |
+| [<abbr title="Society for News Design">SND</abbr>](https://www.snd.org/training/) | April | Design |
+| [SRCCON](https://srccon.org/) | June | Teamwork challenges in news |
+| WordCamp for Publishers | August | WordPress |
+| [<abbr title="Online News Association">ONA</abbr>](https://journalists.org/events/) | September | Online news |

--- a/resources/conferences.md
+++ b/resources/conferences.md
@@ -6,5 +6,5 @@
 | [<abbr title="Investigative Reporters and Editors' Computer Assisted Reporting conference">NICAR</abbr>](https://www.ire.org/conferences) | March | Computer-assisted reporting |
 | [<abbr title="Society for News Design">SND</abbr>](https://www.snd.org/training/) | April | Design |
 | [SRCCON](https://srccon.org/) | June | Teamwork challenges in news |
-| WordCamp for Publishers | August | WordPress |
+| [WordCamp for Publishers](https://twitter.com/wcpublishers/) | August | WordPress |
 | [<abbr title="Online News Association">ONA</abbr>](https://journalists.org/events/) | September | Online news |

--- a/resources/index.md
+++ b/resources/index.md
@@ -4,6 +4,7 @@ Here are the documentation efforts we've undertaken so far:
 
 - [**A Field Guide to Media Tech + Product**](/resources/field-guide)
 - [**Best Practices for News Sites**](/resources/best-practices)
+- [**List of Journalism/Tech Conference**](/resources/conferences)
 
 ## Related Documentation Eforts
 * [18F Guides](https://pages.18f.gov/guides/) - The repository for best practices across 18F project teams.

--- a/resources/index.md
+++ b/resources/index.md
@@ -4,7 +4,7 @@ Here are the documentation efforts we've undertaken so far:
 
 - [**A Field Guide to Media Tech + Product**](/resources/field-guide)
 - [**Best Practices for News Sites**](/resources/best-practices)
-- [**List of Journalism/Tech Conference**](/resources/conferences)
+- [**List of Journalism/Tech Conferences**](/resources/conferences)
 
 ## Related Documentation Eforts
 * [18F Guides](https://pages.18f.gov/guides/) - The repository for best practices across 18F project teams.


### PR DESCRIPTION
## Changes

Creates a conferences page with:
- a short list of conference often attended by newsnerdery.org members
- a list of lists of events that is likely to include other relevant events

This list can be previewed at https://benlk.github.io/newsnerdery/resources/conferences, but since that page's CSS URLs are messed up by being a fork of this repo, here's a guess at how it will appear once merged:

![benlk github io_newsnerdery_resources_conferences](https://user-images.githubusercontent.com/1754187/51343322-2e754580-1a64-11e9-92a1-43eb08f24b18.png)

Note that that screenshot does not have the list of lists of events.

## Why

Resolves https://github.com/newsnerdery/newsnerdery/issues/33 by creating the requested list