### PR TITLE
Add a topic for Media Party; fix columns for same

### DIFF
--- a/resources/conferences.md
+++ b/resources/conferences.md
@@ -6,7 +6,7 @@
 | [<abbr title="Investigative Reporters and Editors' Computer Assisted Reporting conference">NICAR</abbr>](https://www.ire.org/conferences) | March | Computer-assisted reporting | United States |
 | [<abbr title="Society for News Design">SND</abbr>](https://www.snd.org/training/) | April | Design | United States |
 | [SRCCON](https://srccon.org/) | June | Teamwork challenges in news | United States |
-| [Media Party](http://mediaparty.info/en/) | August | Buenos Aires |
+| [Media Party](http://mediaparty.info/en/) | August | The future of news | Buenos Aires |
 | [WordCamp for Publishers](https://twitter.com/wcpublishers/) | August | WordPress | United States |
 | [<abbr title="Online News Association">ONA</abbr>](https://journalists.org/events/) | September | Online news | United States |
 


### PR DESCRIPTION
## Changes

- sets the "Topic" column for Media Party, and sets it to "The future of news"

## Why

Because the columns were misaligned.

<img width="834" alt="screen shot 2019-01-18 at 10 24 45 am" src="https://user-images.githubusercontent.com/1754187/51395698-700cfb80-1b0b-11e9-9873-0dc6f376eee9.png">
