### PR TITLE
Add section for lists of conferences not in news, but relevant to news nerd work

### DIFF
--- a/resources/conferences.md
+++ b/resources/conferences.md
@@ -12,8 +12,12 @@
 
 ## Lists of lists of events
 
+News lists:
 - [OpenNews Source's list of event roundups](https://source.opennews.org/articles/tags/events/)
 - [Hacks/Hackers event list](https://hackshackers.com/)
 - [IRE events and training calendar](https://www.ire.org/events-and-training)
 - [ONA events calendar](https://journalists.org/events/)
 - [SND events calendar](https://www.snd.org/industry-events/)
+
+Relevant tech lists:
+- [CSS-Tricks' list of front-end design and dev conferences](https://conferences.css-tricks.com/)


### PR DESCRIPTION
This starts a list of lists of conferences that aren't directly related to news, but are related to the work that news nerds do in some fashion.