### PR TITLE
Add JS rigs starter list, updated index.

### DIFF
--- a/resources/index.md
+++ b/resources/index.md
@@ -4,6 +4,7 @@ Here are the documentation efforts we've undertaken so far:
 
 - [**A Field Guide to Media Tech + Product**](/resources/field-guide)
 - [**Best Practices for News Sites**](/resources/best-practices)
+- [**JavaScript template rigs**](/resources/template-rigs)
 - [**List of Journalism/Tech Conferences**](/resources/conferences)
 
 ## Related Documentation Eforts

--- a/resources/template-rigs.md
+++ b/resources/template-rigs.md
@@ -1,0 +1,19 @@
+# JavaScript template rigs
+
+*May 16, 2019*
+
+## NPR Apps
+Interactive Template — Provides everything you need to start building a news app or interactive graphic.  
+https://github.com/nprapps/interactive-template
+
+## Politico
+generator-politico-interactives — A Yeoman generator to scaffold a development environment for building POLITICO interactives.  
+https://github.com/The-Politico/generator-politico-interactives
+
+Gootenberg — A tool for handling everything a news developer needs from the Google API.  
+https://github.com/The-Politico/gootenberg
+
+## Texas Tribune
+data-visuals-create — A tool for generating the scaffolding needed to create a graphic or feature the Data Visuals way.  
+https://github.com/texastribune/data-visuals-create
+


### PR DESCRIPTION
A starting point for a list of handy newsroom JavaScript rigs.